### PR TITLE
adds grunt-cli as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "connect": "^3.3.5",
     "grunt": "^0.4.5",
     "grunt-asar": "^0.1.5",
+    "grunt-cli": "^0.1.13",
     "grunt-contrib-clean": "^0.6.0",
     "grunt-contrib-concat": "^0.5.1",
     "grunt-contrib-connect": "^0.10.1",


### PR DESCRIPTION
Adds grunt-cli as a dev dependency so those without it globally installed can still follow the docs and get the boilerplate running.