### PR TITLE
Update Gruntfile.js

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -6,7 +6,7 @@ module.exports = function(grunt) {
       dist: {
         src: [
           'lib/melonJS.js',
-          'lib/plugins/*.js',
+          'lib/plugins/**/*.js',
           'js/game.js',
           'build/js/resources.js',
           'js/**/*.js',


### PR DESCRIPTION
Plugins aren't properly compiled if they are in sub directories like debugbar.

There is either this option of compiling into into app.min.js or extend the copy command to include copying lib/** files